### PR TITLE
Replace What3WordsV3 with What3WordsAndroidWrapper

### DIFF
--- a/multi-component-sample/src/androidTest/java/com/what3words/samples/multiple/test/steps/VoiceSteps.kt
+++ b/multi-component-sample/src/androidTest/java/com/what3words/samples/multiple/test/steps/VoiceSteps.kt
@@ -18,6 +18,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import com.what3words.androidwrapper.What3WordsV3
+import com.what3words.androidwrapper.voice.VoiceProvider
 import com.what3words.components.R
 import com.what3words.components.maps.extensions.generateUniqueId
 import com.what3words.javawrapper.response.Coordinates
@@ -40,19 +41,15 @@ class VoiceSteps(
     private val scenarioHolder: ActivityScenarioHolder
 ) :
     SemanticsNodeInteractionsProvider by composeRuleHolder.composeRule {
-    private lateinit var mockVoiceApi: MockVoiceApi
+    private lateinit var mockVoiceApi: VoiceProvider
 
     @Given("The main screen is visible voice")
     fun theMainScreenIsVisible() {
         composeRuleHolder.composeRule.setContent {
             val viewModel = MultiComponentsViewModel()
             val context = LocalContext.current
-            val wrapper = What3WordsV3(BuildConfig.W3W_API_KEY, context)
             val ocrWrapper = W3WOcrMLKitWrapper(context = context)
-            val dataProvider = What3WordsV3(
-                BuildConfig.W3W_API_KEY,
-                context
-            )
+
             val selectedSuggestion by viewModel.selectedSuggestion.collectAsState()
             val mockDataSound = context.assets.open("soundFilledCountSoap.dat")
 
@@ -61,16 +58,20 @@ class VoiceSteps(
                 mockDataSound = mockDataSound
             )
 
+            val dataProvider = What3WordsV3(
+                apiKey = BuildConfig.W3W_API_KEY,
+                context = context,
+                voiceProvider = mockVoiceApi
+            )
+
             MainAppScreen(
-                wrapper,
+                dataProvider,
                 ocrWrapper,
                 true,
-                dataProvider,
                 selectedSuggestion = selectedSuggestion,
                 onSuggestionChanged = {
                     viewModel.selectedSuggestion.value = it
-                },
-                voiceProvider = mockVoiceApi
+                }
             )
         }
     }

--- a/multi-component-sample/src/main/java/com/what3words/samples/multiple/MultiComponentsActivity.kt
+++ b/multi-component-sample/src/main/java/com/what3words/samples/multiple/MultiComponentsActivity.kt
@@ -6,9 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import com.what3words.androidwrapper.What3WordsAndroidWrapper
 import com.what3words.androidwrapper.What3WordsV3
-import com.what3words.androidwrapper.voice.VoiceApi
 import com.what3words.ocr.components.models.W3WOcrMLKitWrapper
 import com.what3words.ocr.components.models.W3WOcrWrapper
 import com.what3words.samples.multiple.ui.screen.MainAppScreen
@@ -16,13 +14,12 @@ import com.what3words.samples.multiple.ui.screen.MainAppScreen
 class MultiComponentsActivity : ComponentActivity() {
     private val viewModel: MultiComponentsViewModel by viewModels()
     private lateinit var ocrWrapper: W3WOcrWrapper
-    private val dataProvider: What3WordsAndroidWrapper by lazy {
+    private val dataProvider by lazy {
         What3WordsV3(
             BuildConfig.W3W_API_KEY,
             this
         )
     }
-    private val voiceProvider = VoiceApi(BuildConfig.W3W_API_KEY)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -40,8 +37,7 @@ class MultiComponentsActivity : ComponentActivity() {
                 selectedSuggestion = selectedSuggestion,
                 onSuggestionChanged = {
                     viewModel.selectedSuggestion.value = it
-                },
-                voiceProvider = voiceProvider
+                }
             )
         }
     }

--- a/multi-component-sample/src/main/java/com/what3words/samples/multiple/MultiComponentsActivity.kt
+++ b/multi-component-sample/src/main/java/com/what3words/samples/multiple/MultiComponentsActivity.kt
@@ -24,16 +24,14 @@ class MultiComponentsActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         ocrWrapper = W3WOcrMLKitWrapper(context = this@MultiComponentsActivity)
-        val wrapper = What3WordsV3(BuildConfig.W3W_API_KEY, this)
 
         setContent {
             val selectedSuggestion by viewModel.selectedSuggestion.collectAsState()
 
             MainAppScreen(
-                wrapper,
+                dataProvider,
                 ocrWrapper,
                 true,
-                dataProvider,
                 selectedSuggestion = selectedSuggestion,
                 onSuggestionChanged = {
                     viewModel.selectedSuggestion.value = it

--- a/multi-component-sample/src/main/java/com/what3words/samples/multiple/ui/screen/MainAppScreen.kt
+++ b/multi-component-sample/src/main/java/com/what3words/samples/multiple/ui/screen/MainAppScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.what3words.androidwrapper.What3WordsAndroidWrapper
-import com.what3words.androidwrapper.What3WordsV3
-import com.what3words.androidwrapper.voice.VoiceProvider
 import com.what3words.components.maps.models.W3WMarkerColor
 import com.what3words.components.maps.wrappers.W3WMapWrapper
 import com.what3words.design.library.ui.theme.W3WTheme
@@ -36,11 +34,10 @@ import com.what3words.samples.multiple.ui.theme.W3WMultiComponentTheme
 
 @Composable
 fun MainAppScreen(
-    wrapper: What3WordsV3,
+    wrapper: What3WordsAndroidWrapper,
     ocrWrapper: W3WOcrWrapper,
     isGoogleMapType: Boolean,
     dataProvider: What3WordsAndroidWrapper,
-    voiceProvider: VoiceProvider,
     selectedSuggestion: SuggestionWithCoordinates?,
     onSuggestionChanged: (SuggestionWithCoordinates?) -> (Unit)
 ) {
@@ -54,7 +51,7 @@ fun MainAppScreen(
 
     var autoTextFieldUIState by remember(selectedSuggestion) {
         mutableStateOf(
-            AutoTextFieldUIState(voiceProvider, selectedSuggestion, false)
+            AutoTextFieldUIState(dataProvider.voiceProvider, selectedSuggestion, false)
         )
     }
 

--- a/multi-component-sample/src/main/java/com/what3words/samples/multiple/ui/screen/MainAppScreen.kt
+++ b/multi-component-sample/src/main/java/com/what3words/samples/multiple/ui/screen/MainAppScreen.kt
@@ -34,10 +34,9 @@ import com.what3words.samples.multiple.ui.theme.W3WMultiComponentTheme
 
 @Composable
 fun MainAppScreen(
-    wrapper: What3WordsAndroidWrapper,
+    dataProvider: What3WordsAndroidWrapper,
     ocrWrapper: W3WOcrWrapper,
     isGoogleMapType: Boolean,
-    dataProvider: What3WordsAndroidWrapper,
     selectedSuggestion: SuggestionWithCoordinates?,
     onSuggestionChanged: (SuggestionWithCoordinates?) -> (Unit)
 ) {
@@ -79,7 +78,7 @@ fun MainAppScreen(
                 )
 
                 MapWrapperView(
-                    wrapper,
+                    dataProvider,
                     modifier = Modifier.constrainAs(ref = mapRef) {
                         linkTo(start = parent.start, end = parent.end)
                         top.linkTo(anchor = parent.top)

--- a/multi-component-sample/src/main/java/com/what3words/samples/multiple/ui/screen/view/MapWrapperView.kt
+++ b/multi-component-sample/src/main/java/com/what3words/samples/multiple/ui/screen/view/MapWrapperView.kt
@@ -26,7 +26,7 @@ import com.mapbox.maps.MapView
 import com.mapbox.maps.plugin.animation.MapAnimationOptions.Companion.mapAnimationOptions
 import com.mapbox.maps.plugin.animation.flyTo
 import com.mapbox.maps.plugin.gestures.addOnMapClickListener
-import com.what3words.androidwrapper.What3WordsV3
+import com.what3words.androidwrapper.What3WordsAndroidWrapper
 import com.what3words.components.maps.wrappers.W3WGoogleMapsWrapper
 import com.what3words.components.maps.wrappers.W3WMapBoxWrapper
 import com.what3words.components.maps.wrappers.W3WMapWrapper
@@ -34,7 +34,7 @@ import com.what3words.javawrapper.response.SuggestionWithCoordinates
 
 @Composable
 fun MapWrapperView(
-    wrapper: What3WordsV3,
+    wrapper: What3WordsAndroidWrapper,
     modifier: Modifier,
     isGGMap: Boolean,
     suggestion: SuggestionWithCoordinates?,
@@ -62,7 +62,7 @@ fun MapWrapperView(
 
 @Composable
 private fun GoogleMapView(
-    wrapper: What3WordsV3,
+    wrapper: What3WordsAndroidWrapper,
     modifier: Modifier,
     suggestion: SuggestionWithCoordinates?,
     onMapClicked: () -> (Unit),
@@ -184,7 +184,7 @@ private fun GoogleMapView(
 
 @Composable
 fun MapBoxView(
-    wrapper: What3WordsV3,
+    wrapper: What3WordsAndroidWrapper,
     modifier: Modifier,
     suggestion: SuggestionWithCoordinates?,
     onMapClicked: () -> (Unit),


### PR DESCRIPTION
This allows us and our partners to switch between API/SDK with minimal change in one file and not across multiple where we were using the interface implementation (What3WordsV3) instead of the interface (What3WordsAndroidWrapper)