### PR TITLE
Update wrappers-sample to align with recent core library changes

### DIFF
--- a/wrappers-sample/src/main/java/com/what3words/samples/wrapper/data/W3WSuggestionRepository.kt
+++ b/wrappers-sample/src/main/java/com/what3words/samples/wrapper/data/W3WSuggestionRepository.kt
@@ -11,6 +11,7 @@ import com.what3words.core.types.geometry.W3WGridSection
 import com.what3words.core.types.geometry.W3WRectangle
 import com.what3words.core.types.language.W3WLanguage
 import com.what3words.core.types.language.W3WProprietaryLanguage
+import com.what3words.core.types.language.W3WRFC5646Language
 import com.what3words.core.types.options.W3WAutosuggestOptions
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -54,7 +55,7 @@ class W3WSuggestionRepository(
 
     suspend fun voiceAutosuggest(
         input: W3WAudioStream,
-        voiceLanguage: W3WLanguage,
+        voiceLanguage: W3WRFC5646Language,
         options: W3WAutosuggestOptions?,
         onRawResult: ((String) -> Unit)?,
     ): W3WResult<List<W3WSuggestion>> = suspendCancellableCoroutine { continuation ->

--- a/wrappers-sample/src/main/java/com/what3words/samples/wrapper/presentation/kotlin/MainViewModel.kt
+++ b/wrappers-sample/src/main/java/com/what3words/samples/wrapper/presentation/kotlin/MainViewModel.kt
@@ -11,6 +11,7 @@ import com.what3words.core.types.common.W3WResult
 import com.what3words.core.types.domain.W3WSuggestion
 import com.what3words.core.types.geometry.W3WCoordinates
 import com.what3words.core.types.language.W3WLanguage
+import com.what3words.core.types.language.W3WRFC5646Language
 import com.what3words.samples.wrapper.data.W3WSuggestionRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -71,7 +72,7 @@ class MainViewModel(
     suspend fun autosuggest(input: String) =
         w3WSuggestionRepository.autosuggest(input, null)
 
-    fun autosuggestWithVoice(language: W3WLanguage) {
+    fun autosuggestWithVoice(language: W3WRFC5646Language) {
         viewModelScope.launch {
             when (val result =
                 w3WSuggestionRepository.voiceAutosuggest(microphone, language, null, null)) {


### PR DESCRIPTION
In this PR, I updated the `W3WSuggestionRepository` and `MainViewModel` of the `wrappers-sample` to reflect the recent changes made to the `W3WVoiceDataSource` API