### PR TITLE
Fix the bug in the convertTo3wa text parser

### DIFF
--- a/wrappers-sample/src/main/java/com/what3words/samples/wrapper/presentation/kotlin/MainActivity.kt
+++ b/wrappers-sample/src/main/java/com/what3words/samples/wrapper/presentation/kotlin/MainActivity.kt
@@ -43,7 +43,7 @@ class MainActivity : AppCompatActivity() {
         // convert-to-3wa sample
         binding.buttonConvertTo3wa.setOnClickListener {
             val latLong =
-                binding.textInputConvertTo3wa.text?.replace("\\s".toRegex(), "")?.split(",")
+                binding.textInputConvertTo3wa.text?.replace("\\s".toRegex(), "")?.split(Regex(","),  2)
                     ?.filter { it.isNotEmpty() }
             val lat = latLong?.getOrNull(0)?.toDoubleOrNull()
             val long = latLong?.getOrNull(1)?.toDoubleOrNull()


### PR DESCRIPTION
In this PR, I modified the split function on the`textInputConvertTo3wa.text`, to split by a comma (,) and limit the result to 2 parts.